### PR TITLE
Refactor seller FSM and adjust agent creation

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -20,10 +20,10 @@ public class Main {
         AgentContainer container = rt.createMainContainer(profile);
         try {
             container.createNewAgent(Constants.JACK, BuyerAgent.class.getName(), null).start();
-            container.createNewAgent(Constants.LILI, SellerAgent.class.getName(), new Object[]{2700}).start();
-            container.createNewAgent(Constants.LOLA, SellerAgent.class.getName(), new Object[]{2800}).start();
-            container.createNewAgent(Constants.JIM, SellerAgent.class.getName(), new Object[]{-1}).start();
-            container.createNewAgent(Constants.LULU, SellerAgent.class.getName(), new Object[]{2400}).start();
+            container.createNewAgent(Constants.LILI, SellerAgent.class.getName(), new Object[]{"2700"}).start();
+            container.createNewAgent(Constants.LOLA, SellerAgent.class.getName(), new Object[]{"2800"}).start();
+            container.createNewAgent(Constants.JIM, SellerAgent.class.getName(), null).start();
+            container.createNewAgent(Constants.LULU, SellerAgent.class.getName(), new Object[]{"2400"}).start();
         } catch (StaleProxyException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Summary
- rewrite `SellerAgent` with an internal FSMBehaviour
- add message filtering with MessageTemplate and clean termination
- manage initialization arguments and message content
- update `Main` to pass price strings and omit price for Jim

## Testing
- `javac src/*.java` *(fails: package jade not found)*

------
https://chatgpt.com/codex/tasks/task_e_686287020f648321af49c6aaa3a1eea4